### PR TITLE
feat: Add important note about stock order in `.env` file and sample outputs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ ALLOCATION_C=10
 
 # Total amount to invest in dollars
 # This sets the total size of your portfolio in USD
-TOTAL_AMOUNT=7000
+TOTAL_AMOUNT=20000
 
 # Geometric ratio for stock allocation within each list (0-1)
 # This determines how quickly the allocation decreases for each subsequent stock in a list.
@@ -49,7 +49,7 @@ STOCK_LIMIT=0
 # Stocks that would be allocated less than this amount will be removed from the final allocation.
 # Set to 0 for no minimum. This helps to avoid very small positions in your portfolio.
 # Note: Setting this too high might result in fewer stocks than your STOCK_LIMIT.
-MIN_DOLLAR_AMOUNT=500
+MIN_DOLLAR_AMOUNT=0
 
 # Note on STOCK_LIMIT and MIN_DOLLAR_AMOUNT interaction:
 # The script will attempt to meet both the STOCK_LIMIT and MIN_DOLLAR_AMOUNT requirements.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,15 @@ This project allows you to create a personalized ETF (Exchange-Traded Fund) by a
 - Configurable maximum number of stocks and minimum dollar amount per stock
 - Automated requirements management and virtual environment setup
 
+## Important Note: Stock Order Matters!
+
+The order of stocks in your lists is critically important for the allocation process. The geometric allocation strategy assigns higher weights to stocks listed earlier in each list. This means:
+
+1. Stocks listed first will receive larger allocations.
+2. Changing the order of stocks can significantly alter the final allocation.
+
+Always carefully consider the order when defining your stock lists in the `.env` file.
+
 ## Prerequisites
 
 - Python 3.7+
@@ -40,6 +49,94 @@ Run the main script to generate your personal ETF allocation:
 ```sh
 make run
 ```
+
+## Sample Outputs
+
+Here are some sample outputs to illustrate how the allocation works and the importance of stock order:
+
+### Example 1: Default Configuration
+
+```
+Total Portfolio: $20000.00
+
+Rank | Stock | Allocation | Dollar Amount
+---------------------------------------
+   1 | CRWD   |     15.72% | $    3143.33
+   2 | KNSL   |     13.36% | $    2671.83
+   3 | CAVA   |     11.36% | $    2271.06
+   4 | TTD    |      9.65% | $    1930.40
+   5 | TMDX   |      8.20% | $    1640.84
+   6 | AMZN   |      6.97% | $    1394.71
+   7 | ARM    |      5.93% | $    1185.51
+   8 | ABNB   |      5.04% | $    1007.68
+   9 | SNOW   |      4.28% | $     856.53
+  10 | SHOP   |      3.64% | $     728.05
+  11 | MELI   |      3.09% | $     618.84
+  12 | META   |      2.63% | $     526.02
+  13 | CHWY   |      2.24% | $     447.11
+  14 | TSLA   |      1.90% | $     380.05
+  15 | IBM    |      1.62% | $     323.04
+  16 | SMCI   |      1.37% | $     274.58
+  17 | NVIDIA |      1.17% | $     233.40
+  18 | MU     |      0.99% | $     198.39
+  19 | AMD    |      0.84% | $     168.63
+---------------------------------------
+Total:        |    100.00% | $   20000.00
+```
+
+### Example 2: Changing Stock Order
+
+If we move TSLA to the top of the list:
+
+```
+Total Portfolio: $20000.00
+
+Rank | Stock | Allocation | Dollar Amount
+---------------------------------------
+   1 | CRWD   |     15.72% | $    3143.33
+   2 | TSLA   |     13.36% | $    2671.83
+   3 | CAVA   |     11.36% | $    2271.06
+   4 | KNSL   |      9.65% | $    1930.40
+   5 | TMDX   |      8.20% | $    1640.84
+   6 | AMZN   |      6.97% | $    1394.71
+   7 | ARM    |      5.93% | $    1185.51
+   8 | TTD    |      5.04% | $    1007.68
+   9 | ABNB   |      4.28% | $     856.53
+  10 | SNOW   |      3.64% | $     728.05
+  11 | SHOP   |      3.09% | $     618.84
+  12 | MELI   |      2.63% | $     526.02
+  13 | META   |      2.24% | $     447.11
+  14 | CHWY   |      1.90% | $     380.05
+  15 | IBM    |      1.62% | $     323.04
+  16 | SMCI   |      1.37% | $     274.58
+  17 | NVIDIA |      1.17% | $     233.40
+  18 | MU     |      0.99% | $     198.39
+  19 | AMD    |      0.84% | $     168.63
+---------------------------------------
+Total:        |    100.00% | $   20000.00
+```
+
+Notice how TSLA now has the second highest allocation, significantly changing the distribution of funds.
+
+### Example 3: With Stock Limit and Minimum Dollar Amount
+
+Setting STOCK_LIMIT=5 and MIN_DOLLAR_AMOUNT=1000:
+
+```
+Total Portfolio: $20000.00
+
+Rank | Stock | Allocation | Dollar Amount
+---------------------------------------
+   1 | CRWD   |     26.96% | $    5392.83
+   2 | KNSL   |     22.92% | $    4583.90
+   3 | CAVA   |     19.48% | $    3896.32
+   4 | TTD    |     16.56% | $    3311.87
+   5 | TMDX   |     14.08% | $    2815.09
+---------------------------------------
+Total:        |    100.00% | $   20000.00
+```
+
+This example shows how the stock limit and minimum dollar amount affect the allocation, concentrating the investment in fewer stocks while ensuring each has a significant allocation.
 
 ## Development
 


### PR DESCRIPTION
This commit adds an important note about how the order of stocks in the `.env`
file affects the allocation process. It also includes sample outputs to
illustrate the impact of changing stock order on allocation.