### PR TITLE
feat: Separate total and new investments with distinct allocations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,69 +1,14 @@
-# Stock Allocation Tool Configuration
-# This file serves as a template and documentation for the .env file used by the stock allocation tool.
-# Copy this file to .env and adjust the values according to your preferences.
+# Total portfolio stock list
+STOCK_LIST_TOTAL=AVUV,IETC,BUG,XLV,SOXQ,AMZN,MELI,CCJ,TEVA,ZS,COST,PANW,ELF,MU,AMD,CEG,CHWY,GMED,VLTO,SNOW,IBM,AAPL
 
-# Stock Lists
-# Define your stock portfolios here. Each list is a comma-separated string of stock symbols.
-# You can modify these lists to include stocks from any source of advice or personal research.
+# New investment stock list
+STOCK_LIST_NEW=AVUV,IETC,BUG,XLV,SOXQ
 
-# First stock list (e.g., from a financial website, advisor, or personal research)
-STOCK_LIST_A=CRWD,KNSL,TTD,ABNB,SHOP,MELI,SNOW,CHWY,TSLA
+# Investment amounts
+TOTAL_AMOUNT=7000
+NEW_AMOUNT=1000
 
-# Second stock list (e.g., from another source or strategy)
-STOCK_LIST_B=CAVA,TMDX,ARM,AMZN,CRWD,META
-
-# Third stock list (e.g., personal picks or from a different advisor)
-STOCK_LIST_C=SNOW,AMZN,IBM,SMCI,NVIDIA,MU,AMD,ARM
-
-# Portfolio Allocations
-# Define the percentage allocation for each stock list. These should sum to 100.
-# Adjust these values to change the weight of each stock list in your overall portfolio.
-
-# Percentage allocated to Stock List A (0-100)
-ALLOCATION_A=55
-
-# Percentage allocated to Stock List B (0-100)
-ALLOCATION_B=35
-
-# Percentage allocated to Stock List C (0-100)
-ALLOCATION_C=10
-
-# Other Constants
-
-# Total amount to invest in dollars
-# This sets the total size of your portfolio in USD
-TOTAL_AMOUNT=20000
-
-# Geometric ratio for stock allocation within each list (0-1)
-# This determines how quickly the allocation decreases for each subsequent stock in a list.
-# A higher value (closer to 1) results in a more even distribution.
-# A lower value (closer to 0) heavily favors the top stocks in each list.
-GEOMETRIC_RATIO=0.85
-
-# Maximum number of stocks to include in the final allocation
-# Set to 0 for no limit. This helps to focus your portfolio on your top picks.
-# A lower number will result in a more concentrated portfolio.
+# Allocation parameters
+GEOMETRIC_RATIO=0.8
 STOCK_LIMIT=0
-
-# Minimum dollar amount for any single stock allocation
-# Stocks that would be allocated less than this amount will be removed from the final allocation.
-# Set to 0 for no minimum. This helps to avoid very small positions in your portfolio.
-# Note: Setting this too high might result in fewer stocks than your STOCK_LIMIT.
 MIN_DOLLAR_AMOUNT=0
-
-# Note on STOCK_LIMIT and MIN_DOLLAR_AMOUNT interaction:
-# The script will attempt to meet both the STOCK_LIMIT and MIN_DOLLAR_AMOUNT requirements.
-# If it's not possible to meet both, it will prioritize the MIN_DOLLAR_AMOUNT,
-# which may result in fewer stocks than specified by STOCK_LIMIT.
-# If no combination can meet the MIN_DOLLAR_AMOUNT for multiple stocks,
-# the script will allocate 100% to the top stock.
-
-# Tips for customizing your stock lists:
-# 1. You can add more stock lists (e.g., STOCK_LIST_D, ALLOCATION_D) if needed.
-# 2. Ensure that the total of all ALLOCATIONs sums to 100.
-# 3. You can use these lists for different strategies, such as:
-#    - Different sectors (tech, healthcare, finance, etc.)
-#    - Different market caps (large-cap, mid-cap, small-cap)
-#    - Different geographic regions (US, Europe, Emerging Markets, etc.)
-#    - Different investment styles (growth, value, dividend, etc.)
-# 4. Regularly review and update your stock lists based on your research and market conditions.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Personal ETF Creator
 
-This project allows you to create a personalized ETF (Exchange-Traded Fund) by allocating stocks from different lists with custom weightings. It uses a geometric allocation strategy to distribute investments across selected stocks.
+This project allows you to create a personalized ETF (Exchange-Traded Fund) by allocating stocks from different lists with custom weightings. It uses a geometric allocation strategy to distribute investments across selected stocks. The script now handles both your total portfolio and new investments separately.
 
 ## Features
 
-- Define multiple stock lists with custom allocations
+- Define multiple stock lists for total portfolio and new investments
 - Geometric allocation strategy for stock weighting
 - Configurable maximum number of stocks and minimum dollar amount per stock
+- Separate calculations for total portfolio and new investments
 - Automated requirements management and virtual environment setup
 
 ## Important Note: Stock Order Matters!
@@ -50,93 +51,79 @@ Run the main script to generate your personal ETF allocation:
 make run
 ```
 
-## Sample Outputs
+## Configuration
 
-Here are some sample outputs to illustrate how the allocation works and the importance of stock order:
-
-### Example 1: Default Configuration
+Update the `.env` file with your specific settings:
 
 ```
-Total Portfolio: $20000.00
+# Total portfolio stock list
+STOCK_LIST_TOTAL=AVUV,IETC,BUG,XLV,SOXQ,AMZN,MELI,CCJ,TEVA,ZS,COST,PANW,ELF,MU,AMD,CEG,CHWY,GMED,VLTO,SNOW,IBM,AAPL
+
+# New investment stock list
+STOCK_LIST_NEW=AVUV,IETC,BUG,XLV,SOXQ
+
+# Investment amounts
+TOTAL_AMOUNT=7000
+NEW_AMOUNT=1000
+
+# Allocation parameters
+GEOMETRIC_RATIO=0.8
+STOCK_LIMIT=0
+MIN_DOLLAR_AMOUNT=0
+```
+
+## Sample Output
+
+Here's a sample output illustrating both the total portfolio and new investment allocations:
+
+```
+TOTAL Portfolio: $7000.00
 
 Rank | Stock | Allocation | Dollar Amount
 ---------------------------------------
-   1 | CRWD   |     15.72% | $    3143.33
-   2 | KNSL   |     13.36% | $    2671.83
-   3 | CAVA   |     11.36% | $    2271.06
-   4 | TTD    |      9.65% | $    1930.40
-   5 | TMDX   |      8.20% | $    1640.84
-   6 | AMZN   |      6.97% | $    1394.71
-   7 | ARM    |      5.93% | $    1185.51
-   8 | ABNB   |      5.04% | $    1007.68
-   9 | SNOW   |      4.28% | $     856.53
-  10 | SHOP   |      3.64% | $     728.05
-  11 | MELI   |      3.09% | $     618.84
-  12 | META   |      2.63% | $     526.02
-  13 | CHWY   |      2.24% | $     447.11
-  14 | TSLA   |      1.90% | $     380.05
-  15 | IBM    |      1.62% | $     323.04
-  16 | SMCI   |      1.37% | $     274.58
-  17 | NVIDIA |      1.17% | $     233.40
-  18 | MU     |      0.99% | $     198.39
-  19 | AMD    |      0.84% | $     168.63
+   1 | AVUV   |     20.08% | $    1405.31
+   2 | IETC   |     16.06% | $    1124.25
+   3 | BUG    |     12.85% | $     899.40
+   4 | XLV    |     10.28% | $     719.52
+   5 | SOXQ   |      8.22% | $     575.61
+   6 | IVV    |      6.58% | $     460.49
+   7 | AMZN   |      5.26% | $     368.39
+   8 | MELI   |      4.21% | $     294.71
+   9 | TEVA   |      3.37% | $     235.77
+  10 | ZS     |      2.69% | $     188.62
+  11 | COST   |      2.16% | $     150.89
+  12 | PANW   |      1.72% | $     120.72
+  13 | ELF    |      1.38% | $      96.57
+  14 | CCJ    |      1.10% | $      77.26
+  15 | ONON   |      0.88% | $      61.81
+  16 | CHWY   |      0.71% | $      49.44
+  17 | MU     |      0.57% | $      39.56
+  18 | AMD    |      0.45% | $      31.64
+  19 | CEG    |      0.36% | $      25.32
+  20 | GMED   |      0.29% | $      20.25
+  21 | VLTO   |      0.23% | $      16.20
+  22 | SNOW   |      0.19% | $      12.96
+  23 | IBM    |      0.15% | $      10.37
+  24 | AAPL   |      0.12% | $       8.30
+  25 | CMG    |      0.09% | $       6.64
 ---------------------------------------
-Total:        |    100.00% | $   20000.00
-```
+Total:        |    100.00% | $    7000.00
 
-### Example 2: Changing Stock Order
-
-If we move TSLA to the top of the list:
-
-```
-Total Portfolio: $20000.00
+NEW Portfolio: $1000.00
 
 Rank | Stock | Allocation | Dollar Amount
 ---------------------------------------
-   1 | CRWD   |     15.72% | $    3143.33
-   2 | TSLA   |     13.36% | $    2671.83
-   3 | CAVA   |     11.36% | $    2271.06
-   4 | KNSL   |      9.65% | $    1930.40
-   5 | TMDX   |      8.20% | $    1640.84
-   6 | AMZN   |      6.97% | $    1394.71
-   7 | ARM    |      5.93% | $    1185.51
-   8 | TTD    |      5.04% | $    1007.68
-   9 | ABNB   |      4.28% | $     856.53
-  10 | SNOW   |      3.64% | $     728.05
-  11 | SHOP   |      3.09% | $     618.84
-  12 | MELI   |      2.63% | $     526.02
-  13 | META   |      2.24% | $     447.11
-  14 | CHWY   |      1.90% | $     380.05
-  15 | IBM    |      1.62% | $     323.04
-  16 | SMCI   |      1.37% | $     274.58
-  17 | NVIDIA |      1.17% | $     233.40
-  18 | MU     |      0.99% | $     198.39
-  19 | AMD    |      0.84% | $     168.63
+   1 | AVUV   |     27.11% | $     271.06
+   2 | IETC   |     21.68% | $     216.84
+   3 | BUG    |     17.35% | $     173.48
+   4 | XLV    |     13.88% | $     138.78
+   5 | SOXQ   |     11.10% | $     111.02
+   6 | IVV    |      8.88% | $      88.82
 ---------------------------------------
-Total:        |    100.00% | $   20000.00
+Total:        |    100.00% | $    1000.00
 ```
 
-Notice how TSLA now has the second highest allocation, significantly changing the distribution of funds.
-
-### Example 3: With Stock Limit and Minimum Dollar Amount
-
-Setting STOCK_LIMIT=5 and MIN_DOLLAR_AMOUNT=1000:
-
-```
-Total Portfolio: $20000.00
-
-Rank | Stock | Allocation | Dollar Amount
----------------------------------------
-   1 | CRWD   |     26.96% | $    5392.83
-   2 | KNSL   |     22.92% | $    4583.90
-   3 | CAVA   |     19.48% | $    3896.32
-   4 | TTD    |     16.56% | $    3311.87
-   5 | TMDX   |     14.08% | $    2815.09
----------------------------------------
-Total:        |    100.00% | $   20000.00
-```
-
-This example shows how the stock limit and minimum dollar amount affect the allocation, concentrating the investment in fewer stocks while ensuring each has a significant allocation.
+This output shows how the script allocates both your total portfolio and your new investment, allowing you to see where to put your new money every two weeks without fully reallocating the entire portfolio.
 
 ## Development
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
 import os
 from dotenv import load_dotenv
-from collections import defaultdict
 
 # Load environment variables
 load_dotenv()
@@ -15,45 +14,11 @@ def get_stock_lists():
     return stock_lists
 
 
-def get_allocations():
-    allocations = {}
-    for key, value in os.environ.items():
-        if key.startswith("ALLOCATION_"):
-            list_id = key.split("_")[-1]
-            allocations[list_id] = float(value)
-    return allocations
-
-
-def allocate_stocks(stocks, total_percentage, ratio):
+def allocate_stocks(stocks, ratio):
     weights = [ratio**i for i in range(len(stocks))]
     total_weight = sum(weights)
-    percentages = [weight / total_weight * total_percentage for weight in weights]
+    percentages = [weight / total_weight * 100 for weight in weights]
     return dict(zip(stocks, percentages))
-
-
-def combine_allocations(allocations_list):
-    combined = defaultdict(float)
-    for allocations in allocations_list:
-        for stock, percentage in allocations.items():
-            combined[stock] += percentage
-    return dict(combined)
-
-
-def print_allocations(allocations, total_amount):
-    print(f"Total Portfolio: ${total_amount:.2f}")
-    print("\nRank | Stock | Allocation | Dollar Amount")
-    print("---------------------------------------")
-    total_percentage = 0
-    total_dollars = 0
-    for rank, (stock, percentage) in enumerate(
-        sorted(allocations.items(), key=lambda x: x[1], reverse=True), 1
-    ):
-        dollars = percentage / 100 * total_amount
-        print(f"{rank:4d} | {stock:<6} | {percentage:>9.2f}% | ${dollars:>11.2f}")
-        total_percentage += percentage
-        total_dollars += dollars
-    print("---------------------------------------")
-    print(f"Total:        | {total_percentage:>9.2f}% | ${total_dollars:>11.2f}")
 
 
 def limit_and_reallocate(allocations, limit, ratio, total_amount, min_dollar_amount):
@@ -84,59 +49,43 @@ def limit_and_reallocate(allocations, limit, ratio, total_amount, min_dollar_amo
     return {sorted_stocks[0][0]: 100.0}
 
 
-def validate_inputs(stock_lists, allocations):
-    stock_list_ids = set(stock_lists.keys())
-    allocation_ids = set(allocations.keys())
-
-    if stock_list_ids != allocation_ids:
-        missing_stocks = allocation_ids - stock_list_ids
-        missing_allocations = stock_list_ids - allocation_ids
-        error_message = (
-            "Mismatch between STOCK_LIST and ALLOCATION environment variables\n"
-        )
-        if missing_stocks:
-            error_message += (
-                f"Missing stock lists for allocations: {', '.join(missing_stocks)}\n"
-            )
-        if missing_allocations:
-            error_message += f"Missing allocations for stock lists: {', '.join(missing_allocations)}\n"
-        raise ValueError(error_message)
-
-    total_allocation = sum(allocations.values())
-    if abs(total_allocation - 100) > 0.01:
-        raise ValueError(
-            f"Sum of allocation percentages must equal 100, but it's {total_allocation}"
-        )
+def print_allocations(allocations, total_amount, title):
+    print(f"\n{title}: ${total_amount:.2f}")
+    print("\nRank | Stock | Allocation | Dollar Amount")
+    print("---------------------------------------")
+    total_percentage = 0
+    total_dollars = 0
+    for rank, (stock, percentage) in enumerate(
+        sorted(allocations.items(), key=lambda x: x[1], reverse=True), 1
+    ):
+        dollars = percentage / 100 * total_amount
+        print(f"{rank:4d} | {stock:<6} | {percentage:>9.2f}% | ${dollars:>11.2f}")
+        total_percentage += percentage
+        total_dollars += dollars
+    print("---------------------------------------")
+    print(f"Total:        | {total_percentage:>9.2f}% | ${total_dollars:>11.2f}")
 
 
 def main():
     total_amount = float(os.getenv("TOTAL_AMOUNT"))
+    new_amount = float(os.getenv("NEW_AMOUNT"))
     geometric_ratio = float(os.getenv("GEOMETRIC_RATIO"))
     stock_limit = int(os.getenv("STOCK_LIMIT", "0"))
     min_dollar_amount = float(os.getenv("MIN_DOLLAR_AMOUNT", "0"))
 
     stock_lists = get_stock_lists()
-    allocations = get_allocations()
 
-    validate_inputs(stock_lists, allocations)
-
-    individual_allocations = []
-    for list_id, stocks in stock_lists.items():
-        individual_allocations.append(
-            allocate_stocks(stocks, allocations[list_id], geometric_ratio)
+    for list_id, amount in [("TOTAL", total_amount), ("NEW", new_amount)]:
+        stocks = stock_lists[list_id]
+        allocations = allocate_stocks(stocks, geometric_ratio)
+        final_allocations = limit_and_reallocate(
+            allocations,
+            stock_limit,
+            geometric_ratio,
+            amount,
+            min_dollar_amount,
         )
-
-    combined_allocations = combine_allocations(individual_allocations)
-
-    final_allocations = limit_and_reallocate(
-        combined_allocations,
-        stock_limit,
-        geometric_ratio,
-        total_amount,
-        min_dollar_amount,
-    )
-
-    print_allocations(final_allocations, total_amount)
+        print_allocations(final_allocations, amount, f"{list_id} Portfolio")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Update the script to handle total portfolio and new investments individually. Add allocation logic for new investments based on a specified amount. Display allocations separately for total and new portfolios.